### PR TITLE
cityIO data is being passed to cityio-grid-maker child-service

### DIFF
--- a/src/app/basemap/cityio/cityio-grid-maker/cityio-grid-maker.service.spec.ts
+++ b/src/app/basemap/cityio/cityio-grid-maker/cityio-grid-maker.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from "@angular/core/testing";
+
+import { CityioGridMakerService } from "../cityio-grid-maker/cityio-grid-maker.service";
+
+describe("CityioGridMakerService", () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it("should be created", () => {
+    const service: CityioGridMakerService = TestBed.get(CityioGridMakerService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/basemap/cityio/cityio-grid-maker/cityio-grid-maker.service.ts
+++ b/src/app/basemap/cityio/cityio-grid-maker/cityio-grid-maker.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from "@angular/core";
+
+@Injectable({
+  providedIn: "root"
+})
+export class CityioGridMakerService {
+  constructor() {}
+
+  makeGridFromCityIO(cityiodata: any): GeoJsonPolygon[] {
+    /**
+     * Constructs and returns the GeoJsonPolygon grid cells from the
+     * passed in CityIO data.
+     *
+     * @param nrows: number of rows in the cityIO grid
+     * @param ncols: number of columns in the cityIO grid
+     * @param gridCellSize: size of grid cell in meters
+     * @returns and array of GeoJsonPolygons.
+     **/
+
+    let gridCellSize = cityiodata.header.spatial.cellSize,
+      nrows = cityiodata.header.spatial.nrows,
+      ncols = cityiodata.header.spatial.ncols,
+      grid = cityiodata.grid;
+
+    let polygons = [];
+    for (var row = 0; row < nrows; row++) {
+      for (var col = 0; col < ncols; col++) {
+        // Make geoJsonPolygon
+        let polygonCoordinates = this.generateCoordinatesFromCityIOData(
+          row,
+          col,
+          gridCellSize
+        );
+        let polygon = new GeoJsonPolygon(polygonCoordinates);
+        polygons.push(polygon);
+      }
+    }
+    return polygons;
+  }
+
+  private generateCoordinatesFromCityIOData(
+    /**
+     * make polygon coordinates array
+     *
+     * @param row: number of rows in the cityIO grid
+     * @param col: number of columns in the cityIO grid
+     * @param gridCellSize: size of grid cell in meters
+     * @returns and array of .
+     **/
+    row: number,
+    col: number,
+    gridCellSize: number
+  ): number[][] {
+    let squareSize = gridCellSize;
+    let polygonCoordinates = [
+      [0, 0],
+      [0, 0, squareSize, 0],
+      [0, 0, squareSize, squareSize],
+      [0, 0, 0, squareSize],
+      [0, 0]
+    ];
+    return polygonCoordinates;
+  }
+}
+
+export class GeoJsonPolygon {
+  type = "Feature";
+  geometry: IGeometry;
+  constructor(coordinates, public properties?) {
+    this.geometry = {
+      type: "Polygon",
+      coordinates: [coordinates]
+    };
+    this.properties = properties ? properties : defaultGeoJsonProperties;
+  }
+}
+
+export interface IGeometry {
+  type: string;
+  coordinates: number[];
+}
+
+export interface IGeoJson {
+  type: string;
+  geometry: IGeometry;
+  properties?: any;
+  $key?: string;
+}
+
+export const defaultGeoJsonProperties = {
+  name: "empty",
+  color: "gray",
+  baseHeight: 0,
+  height: 0
+};

--- a/src/app/basemap/cityio/cityio.component.ts
+++ b/src/app/basemap/cityio/cityio.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { CityioService } from "./cityio.service";
+import { CityioGridMakerService } from "./cityio-grid-maker/cityio-grid-maker.service";
 
 @Component({
   selector: "app-cityio",
@@ -10,6 +11,11 @@ import { CityioService } from "./cityio.service";
   `
 })
 export class CityioComponent implements OnInit {
+  // flag for first init of grid
+  initGrid: number = 0;
+  cityIOgridMaker: any = new CityioGridMakerService();
+  cityiodata: JSON;
+
   constructor(private cityIOservice: CityioService) {}
   title = "cityIO status...";
   ngOnInit() {
@@ -19,7 +25,15 @@ export class CityioComponent implements OnInit {
   getCityIOatInterval() {
     setInterval(() => {
       this.cityIOservice.getCityIOdata().subscribe(cityiodata => {
+        this.cityiodata = cityiodata;
         this.title = "cityIO timestamp " + cityiodata.meta.timestamp;
+        // check if this is the first run for grid init
+        if (this.cityiodata !== null && this.initGrid == 0) {
+          console.log("making baseline grid...");
+          // pass cityio data to the init grid maker function at service
+          this.cityIOgridMaker.makeGridFromCityIO(this.cityiodata);
+          this.initGrid = 1;
+        }
       });
     }, 1000);
   }


### PR DESCRIPTION
`cityio-grid-maker` is a small subservice that will handle the first grid creation, georef it, and later the updating of grids as data comes from cityIO.
To do: return a grid as geojson with proper locations of for each cell 