### PR TITLE
removed separated CS table entry point

### DIFF
--- a/src/app/basemap/basemap.component.scss
+++ b/src/app/basemap/basemap.component.scss
@@ -24,9 +24,6 @@
   position: relative;
 }
 
-.modal-container {
-}
-
 .container-left-bottom {
   position: absolute;
   bottom: 30px;
@@ -48,6 +45,3 @@
 .container-right-top.save {
   top: 69px;
 }
-
-
-

--- a/src/app/basemap/basemap.component.ts
+++ b/src/app/basemap/basemap.component.ts
@@ -4,15 +4,7 @@ import { interval } from "rxjs";
 import * as mapboxgl from "mapbox-gl";
 import * as Maptastic from "maptastic/dist/maptastic.min.js";
 import { CsLayer } from "../../typings";
-import {
-  AnySourceData,
-  Layer,
-  LngLat,
-  LngLatBoundsLike,
-  MapboxGeoJSONFeature,
-  LngLatBounds,
-  LngLatLike
-} from "mapbox-gl";
+import { LngLat, LngLatBoundsLike, LngLatLike } from "mapbox-gl";
 import { GeoJSONSource } from "mapbox-gl";
 import { ConfigurationService } from "../services/configuration.service";
 import { LayerLoaderService } from "../services/layer-loader.service";
@@ -251,9 +243,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
     this.mapCanvas.addEventListener("keydown", this.keyStrokeOnMap);
 
     // map multi select for logged in users
-    if (this.authenticationService.currentUserValue) {
-      this.mapCanvas.addEventListener("mousedown", this.mouseDown, true);
-    }
+    this.mapCanvas.addEventListener("mousedown", this.mouseDown, true);
 
     this.map.on("dragstart", e => {
       this.removePopUp();
@@ -281,27 +271,6 @@ export class BasemapComponent implements OnInit, AfterViewInit {
   // Handle all map keystroke interactions
 
   keyStrokeOnMap = e => {
-    if (this.authenticationService.currentUserValue) {
-      let { gridLayer, currentSource } = this.getGridSource();
-      if (e.key === "w") {
-        this.removePopUp();
-        for (let feature of currentSource["features"]) {
-          if (this.selectedFeatures.includes(feature.properties["id"])) {
-            const height = feature.properties["height"];
-            if (height !== null) {
-              if (height < 100) {
-                feature.properties["height"] = height + 1;
-              } else {
-                feature.properties["height"] = 0;
-              }
-            }
-          }
-        }
-        gridLayer.setData(currentSource);
-      }
-      this.localStorageService.saveGrid(currentSource);
-    }
-
     //Keystroke for menu toggle
     if (e.code === "Space") {
       // TODO: we could make this option only available for superusers
@@ -339,10 +308,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
   clickOnGrid = e => {
     //Manipulate the clicked feature
     let clickedFeature = e.features[0];
-    if (this.authenticationService.currentUserValue) {
-      this.showFeaturesSelected([clickedFeature]);
-    }
-
+    this.showFeaturesSelected([clickedFeature]);
     // add a popup data window
     this.popUp = new mapboxgl.Popup()
       .setLngLat(e.lngLat)
@@ -564,17 +530,6 @@ export class BasemapComponent implements OnInit, AfterViewInit {
     this.isShowMenu = !this.isShowMenu;
   }
 
-  private closeAndLogout() {
-    if (
-      this.authenticationService.currentUserValue &&
-      this.localStorageService.getGrid()
-    ) {
-      this.openDialog();
-    } else {
-      this.exitEditor();
-    }
-  }
-
   private saveCurrentChanges() {
     // TODO: send data to cityIO
     this.localStorageService.removeGrid();
@@ -595,8 +550,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
   clickMenuClose = e => {
     this.sliderDisplay = false;
     this.map.off("click", this.clickMenuClose);
-    //
-    // !!!!!
+    // restore grid colors when clikcing out of select box
     let { gridLayer, currentSource } = this.getGridSource();
     for (let feature of currentSource["features"]) {
       if (feature.properties["color"] === "#ff00ff") {

--- a/src/app/basemap/basemap.component.ts
+++ b/src/app/basemap/basemap.component.ts
@@ -20,7 +20,6 @@ import { AppComponent } from "../app.component";
 import { AlertService } from "../services/alert.service";
 import { LocalStorageService } from "../services/local-storage.service";
 import { RestoreMessage } from "../dial/restore-message";
-import { rgb } from "d3";
 
 @NgModule({
   imports: [BrowserModule, FormsModule],

--- a/src/app/basemap/basemap.component.ts
+++ b/src/app/basemap/basemap.component.ts
@@ -20,6 +20,7 @@ import { AppComponent } from "../app.component";
 import { AlertService } from "../services/alert.service";
 import { LocalStorageService } from "../services/local-storage.service";
 import { RestoreMessage } from "../dial/restore-message";
+import { rgb } from "d3";
 
 @NgModule({
   imports: [BrowserModule, FormsModule],
@@ -41,6 +42,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
   mapKeyVisible: boolean;
   layers: CsLayer[] = [];
   intervalMap = {};
+  selectedCellColor = "rgba(255,50,200,0.5)";
 
   // Map config
   center: any;
@@ -326,7 +328,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
     for (let clickedFeature of selectedFeature) {
       for (let feature of currentSource["features"]) {
         if (feature.properties["id"] === clickedFeature.properties["id"]) {
-          if (feature.properties["color"] === "#ff00ff") {
+          if (feature.properties["color"] === this.selectedCellColor) {
             feature.properties["color"] = feature.properties["initial-color"];
             feature.properties["isSelected"] = false;
             // remove this cell from array
@@ -340,7 +342,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
           } else {
             feature.properties["initial-color"] = feature.properties["color"];
             feature.properties["isSelected"] = true;
-            feature.properties["color"] = "#ff00ff";
+            feature.properties["color"] = this.selectedCellColor;
             this.selectedFeatures.push(clickedFeature.properties["id"]);
           }
         }
@@ -530,6 +532,18 @@ export class BasemapComponent implements OnInit, AfterViewInit {
     this.isShowMenu = !this.isShowMenu;
   }
 
+  // close button function
+  private closeAndLogout() {
+    if (
+      this.authenticationService.currentUserValue &&
+      this.localStorageService.getGrid()
+    ) {
+      this.openDialog();
+    } else {
+      this.exitEditor();
+    }
+  }
+
   private saveCurrentChanges() {
     // TODO: send data to cityIO
     this.localStorageService.removeGrid();
@@ -553,7 +567,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
     // restore grid colors when clikcing out of select box
     let { gridLayer, currentSource } = this.getGridSource();
     for (let feature of currentSource["features"]) {
-      if (feature.properties["color"] === "#ff00ff") {
+      if (feature.properties["color"] === this.selectedCellColor) {
         feature.properties["color"] = feature.properties["initial-color"];
         feature.properties["isSelected"] = false;
       }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,7 +1,6 @@
 <div id="splash-image">
   <div class="content">
     <div class="first-header">CityScope</div>
-
     <div class="second-header">
       Gras-
     </div>
@@ -10,7 +9,6 @@
     </div>
 
     <div class="menu" id="menu">
-      <a [routerLink]="['map']">Observatory</a>
       <a [routerLink]="['login']">Editor Login</a>
       <a class="logout" (click)="logout()">Logout</a>
     </div>


### PR DESCRIPTION
This is a bit of a rollback, but might keep code cleaner:
the CS Table (the physical one) is nothing more than a mapbox layer that is not editable. 
Therefore we can remove the separated entry point and if statements that check authentication, and simply add a layer that reads the physical grid. 