### PR TITLE
Account for case sensivity when importing maptastic module

### DIFF
--- a/cityscope_grasbrook_angular/src/app/basemap/basemap.component.ts
+++ b/cityscope_grasbrook_angular/src/app/basemap/basemap.component.ts
@@ -2,7 +2,7 @@ import {AfterViewInit, Component, OnInit, NgZone} from "@angular/core";
 import {environment} from "../../environments/environment";
 import {interval, throwError} from "rxjs";
 import * as mapboxgl from "mapbox-gl";
-import * as Maptastic from "maptastic/dist/maptastic.min.js";
+import * as maptastic from "maptastic/dist/maptastic.min.js";
 import {CsLayer} from "../../typings";
 import {LngLat, LngLatBoundsLike, LngLatLike} from "mapbox-gl";
 import {GeoJSONSource} from "mapbox-gl";
@@ -522,7 +522,7 @@ export class BasemapComponent implements OnInit, AfterViewInit {
     }
 
     toggleMaptasticMode() {
-        Maptastic('basemap');
+        maptastic('basemap');
     }
 
     private toggleMenu() {


### PR DESCRIPTION
@luftj : i had to rename all instances of "Maptastic" into "maptastic" in the maptastic.js and maptastic.min.js ---> these changes probably would not survive a "npm install" if installed on a new machine.
i hope there is a better version of making this work.