### PR TITLE
New use types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11824,8 +11824,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -11846,14 +11845,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11868,20 +11865,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11998,8 +11992,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12011,7 +12004,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12026,7 +12018,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -12034,14 +12025,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12060,7 +12049,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12141,8 +12129,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -12154,7 +12141,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12240,8 +12226,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12277,7 +12262,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12297,7 +12281,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12341,14 +12324,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -12668,8 +12649,7 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -12694,8 +12674,7 @@
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",

--- a/src/app/config.json
+++ b/src/app/config.json
@@ -294,6 +294,52 @@
       }
     },
     {
+      "id": "walkability_grocery",
+      "displayName": "Walkability to grocery stores",
+      "showInLayerList": true,
+      "isLoading": false,
+      "addOnMapInitialisation": false,
+      "metadata": "",
+      "type": "fill-extrusion",
+      "source": {
+        "type": "geojson",
+        "data": "https://cityio.media.mit.edu/api/table/grasbrook_test/walkability"
+      },      
+      "paint": {
+        "fill-extrusion-height": 0.1,
+        "fill-extrusion-base": 0.1,
+        "fill-extrusion-opacity": 0.8,
+        
+        "fill-extrusion-color": {
+          "property": "grocery",
+          "stops": [[0, "green"], [5,"rgb(245, 206, 15)"], [6, "red"]],
+          "default": "red"
+        }
+      },
+      
+      "legend": {
+        "type": "circle",
+        "styleField": "grocery",
+        "styleValues": [{
+            "styleFieldValue": 0,
+            "color": "green",
+            "label": "< 5 minutes"
+          },
+          {
+            "styleFieldValue": 5,
+            "color": "rgb(245, 206, 15)",
+            "label": "5 minutes"
+          },
+          {
+            "styleFieldValue": 6,
+            "color": "red",
+            "label": ">= 6 minutes"
+          }
+        ],
+        "description": "A visualization of walking time (in minutes) needed to reach the closest grocery store."
+      }
+    },
+    {
       "id": "noise_result",
       "displayName": "Traffic noise levels",
       "showInLayerList": true,

--- a/src/app/entities/cell.ts
+++ b/src/app/entities/cell.ts
@@ -206,10 +206,11 @@ export enum BuildingType {
 
 enum BuildingUse {
     residential = "#FF6E40",
-    commercial = "#FF5252",
-    office = "#FF4081",
+    commercial = "#FF4081",
+    office = "#000000",
     educational = "#40C4FF",
     culture = "#7C4DFF",
+    grocery = "#FF5252",
 }
 
 enum OpenSpaceType {

--- a/src/app/entities/cell.ts
+++ b/src/app/entities/cell.ts
@@ -2,7 +2,7 @@ export class GridCell {
 
     type = BuildingType.empty;
 
-    str_speed = 50;
+    str_speed = 30;
     str_numLanes = 0;
     str_bike = true;
     str_stairs = false;
@@ -198,7 +198,7 @@ enum BuildingUse {
 
 enum OpenSpaceType {
     green_space = "#69F0AE",
-    promenade = "#48A377",
+    promenade = "#AFF7D3",
     athletic_field = "#AFF7D3",
     playground = "#AFF7D3",
     daycare_playground = "#AFF7D3",

--- a/src/app/entities/cell.ts
+++ b/src/app/entities/cell.ts
@@ -206,11 +206,11 @@ export enum BuildingType {
 
 enum BuildingUse {
     residential = "#FF6E40",
-    commercial = "#FF4081",
+    commercial = "#FF5252",
     office = "#000000",
     educational = "#40C4FF",
     culture = "#7C4DFF",
-    grocery = "#FF5252",
+    grocery = "#FF4081",
 }
 
 enum OpenSpaceType {

--- a/src/app/entities/cell.ts
+++ b/src/app/entities/cell.ts
@@ -111,7 +111,13 @@ export class GridCell {
                         color = BuildingUse[Object.keys(BuildingUse)[gridCell.bld_useUpper]];
                     }
                 } else if (gridCell[gridCellKey] === 1) {
-                    color = '#333333';
+                    if (GridCell["str_numLanes"] === 0) {
+                        // promenade
+                        color = "#48A377"
+                    } else {
+                        // street
+                        color = '#333333';
+                    }
                     delete feature.properties["height"];
                 } else if (gridCell[gridCellKey] === 2) {
                     color = OpenSpaceType[Object.keys(OpenSpaceType)[gridCell.os_type]];
@@ -150,6 +156,13 @@ export class GridCell {
                     feature.properties['changedTypeColor'] = "#aaaaaa"
                 } else if(typeDict[gridCellKey]=="street") {
                     feature.properties['changedTypeColor'] = "#333333"
+                    if (typeDict["str_numLanes"] === 0) {
+                        // promenade
+                        feature.properties['changedTypeColor'] = "#48A377"
+                    } else {
+                        // street
+                        feature.properties['changedTypeColor'] = "#333333"
+                    }
                 } 
             } else if (gridCellKey === "bld_useUpper") {
                 if (typeDict[gridCellKey] != null) {

--- a/src/app/entities/cell.ts
+++ b/src/app/entities/cell.ts
@@ -114,7 +114,7 @@ export class GridCell {
                 } else if (gridCell[gridCellKey] === 1) {
                     if (gridCell["str_numLanes"] === 0) {
                         // promenade
-                        color = '#48A377'
+                        color = '#48A377';
                     } else {
                         // street
                         color = '#333333';

--- a/src/app/entities/cell.ts
+++ b/src/app/entities/cell.ts
@@ -104,6 +104,7 @@ export class GridCell {
                 feature.properties[gridCellKey] = gridCell[gridCellKey];
                 let color = "";
                 if (gridCell[gridCellKey] === 0) {
+                    // building
                     if (gridCell.bld_useUpper == null) {
                         color = BuildingUse[Object.keys(BuildingUse)[gridCell.bld_useGround]];
                     }
@@ -111,19 +112,21 @@ export class GridCell {
                         color = BuildingUse[Object.keys(BuildingUse)[gridCell.bld_useUpper]];
                     }
                 } else if (gridCell[gridCellKey] === 1) {
-                    if (GridCell["str_numLanes"] === 0) {
+                    if (gridCell["str_numLanes"] === 0) {
                         // promenade
-                        color = "#48A377"
+                        color = '#48A377'
                     } else {
                         // street
                         color = '#333333';
                     }
                     delete feature.properties["height"];
                 } else if (gridCell[gridCellKey] === 2) {
+                    // open space
                     color = OpenSpaceType[Object.keys(OpenSpaceType)[gridCell.os_type]];
                     delete feature.properties["height"];
-                }   else { //type == 3 -> empty
-                    color = "#aaaaaa";
+                }   else {
+                    //type == 3 -> empty
+                    color = '#aaaaaa';
                     delete feature.properties["height"];
                 }
                 feature.properties['changedTypeColor'] = color;

--- a/src/app/menus/edit-menu/edit-menu.component.html
+++ b/src/app/menus/edit-menu/edit-menu.component.html
@@ -58,7 +58,7 @@
 
             <section class="input-holder">
                 <mat-form-field class="form-field">
-                    <input matInput [(ngModel)]="cell.str_numLanes" type="number" placeholder="Number of car lanes"
+                    <input matInput min=0 [(ngModel)]="cell.str_numLanes" type="number" placeholder="Number of car lanes"
                     (change)="onChangeLanes($event)">
                 </mat-form-field>
             </section>

--- a/src/app/menus/edit-menu/edit-menu.component.html
+++ b/src/app/menus/edit-menu/edit-menu.component.html
@@ -61,7 +61,7 @@
             <section class="input-holder">
                 <mat-form-field class="form-field">
                     <input matInput min=0 [(ngModel)]="cell.str_numLanes" type="number" placeholder="Number of car lanes"
-                    (change)="onChangeLanes($event)">
+                    (change)="onChangeLanes(cell.str_numLanes)">
                 </mat-form-field>
             </section>
 

--- a/src/app/menus/edit-menu/edit-menu.component.html
+++ b/src/app/menus/edit-menu/edit-menu.component.html
@@ -25,9 +25,9 @@
                             #selectGroundUse>
                     <mat-option [value]="0">Residential</mat-option>
                     <mat-option [value]="1">Commercial</mat-option>
-                    <mat-option [value]="2">Office</mat-option>
-                    <mat-option [value]="3">Educational</mat-option>
-                    <mat-option [value]="4">Culture - Sports - Community</mat-option>
+                    <!-- <mat-option [value]="2">Office</mat-option> -->
+                    <mat-option [value]="3">Elementary school</mat-option>
+                    <mat-option [value]="4">Community center</mat-option>
                 </mat-select>
                 <mat-error>Please select a building use!</mat-error>
             </mat-form-field>
@@ -42,19 +42,19 @@
                             #selectUpperUse>
                     <mat-option [value]="0">Residential</mat-option>
                     <mat-option [value]="1">Commercial</mat-option>
-                    <mat-option [value]="2">Office</mat-option>
-                    <mat-option [value]="3">Educational</mat-option>
-                    <mat-option [value]="4">Culture - Sports - Community</mat-option>
+                    <!-- <mat-option [value]="2">Office</mat-option> -->
+                    <mat-option [value]="3">Elementary school</mat-option>
+                    <mat-option [value]="4">Community center</mat-option>
                 </mat-select>
                 <mat-error>Please select a building use!</mat-error>
             </mat-form-field>
         </mat-tab>
         <mat-tab label="Tab Street">
             <ng-template mat-tab-label>
-                <mat-icon matTooltip="Street">directions_car</mat-icon>
+                <mat-icon matTooltip="Street">directions_walk</mat-icon>
             </ng-template>
 
-            <div class="category_header">Street</div>
+            <div class="category_header">Street | Promenade</div>
 
             <section class="input-holder">
                 <mat-form-field class="form-field">
@@ -114,13 +114,13 @@
                 <mat-label>Open space type</mat-label>
                 <mat-select [(ngModel)]="cell.os_type" required #selectOSType>
                     <mat-option [value]="0">Green space</mat-option>
-                    <mat-option [value]="1">Promenade</mat-option>
+                    <mat-option [value]="1">Plaza</mat-option>
                     <mat-option [value]="2">Athletic field</mat-option>
-                    <mat-option [value]="3">Playground</mat-option>
-                    <mat-option [value]="4">Daycare (Kita) playground</mat-option>
-                    <mat-option [value]="5">Schoolyard</mat-option>
+                    <!-- <mat-option [value]="3">Playground</mat-option>
+                    <mat-option [value]="4">Daycare (Kita) playground</mat-option> -->
+                    <!-- <mat-option [value]="5">Schoolyard</mat-option>
                     <mat-option [value]="6">Exhibition space</mat-option>
-                    <mat-option [value]="7">Recycling center</mat-option>
+                    <mat-option [value]="7">Recycling center</mat-option> -->
                     <mat-option [value]="8">Water</mat-option>
                 </mat-select>
                 <mat-error>Please select a type!</mat-error>

--- a/src/app/menus/edit-menu/edit-menu.component.html
+++ b/src/app/menus/edit-menu/edit-menu.component.html
@@ -28,6 +28,7 @@
                     <!-- <mat-option [value]="2">Office</mat-option> -->
                     <mat-option [value]="3">Elementary school</mat-option>
                     <mat-option [value]="4">Community center</mat-option>
+                    <mat-option [value]="5">Grocery store</mat-option>
                 </mat-select>
                 <mat-error>Please select a building use!</mat-error>
             </mat-form-field>
@@ -45,6 +46,7 @@
                     <!-- <mat-option [value]="2">Office</mat-option> -->
                     <mat-option [value]="3">Elementary school</mat-option>
                     <mat-option [value]="4">Community center</mat-option>
+                    <mat-option [value]="5">Grocery store</mat-option>
                 </mat-select>
                 <mat-error>Please select a building use!</mat-error>
             </mat-form-field>

--- a/src/app/menus/edit-menu/edit-menu.component.html
+++ b/src/app/menus/edit-menu/edit-menu.component.html
@@ -58,13 +58,15 @@
 
             <section class="input-holder">
                 <mat-form-field class="form-field">
-                    <input matInput [(ngModel)]="cell.str_numLanes" type="number" placeholder="Number of car lanes">
+                    <input matInput [(ngModel)]="cell.str_numLanes" type="number" placeholder="Number of car lanes"
+                    (change)="onChangeLanes($event)">
                 </mat-form-field>
             </section>
 
             <section class="radio-holder">
                 <label>Speed limit</label>
-                <mat-radio-group [(ngModel)]="cell.str_speed">
+                <mat-radio-group [(ngModel)]="cell.str_speed"
+                                [disabled]="speedLimitDisabled">
                     <mat-radio-button [value]="7">7</mat-radio-button>
                     <mat-radio-button [value]="30">30</mat-radio-button>
                     <mat-radio-button [value]="50">50</mat-radio-button>
@@ -81,7 +83,8 @@
 
             <section class="radio-holder">
                 <label>Stairs</label>
-                <mat-radio-group [(ngModel)]="cell.str_stairs">
+                <mat-radio-group [(ngModel)]="cell.str_stairs"
+                                [disabled]="!speedLimitDisabled">
                     <mat-radio-button [value]="true">Yes</mat-radio-button>
                     <mat-radio-button [value]="false"[checked]='true'>No</mat-radio-button>
                 </mat-radio-group>
@@ -89,7 +92,8 @@
 
             <section class="radio-holder">
                 <label>Pedestrian ramp</label>
-                <mat-radio-group [(ngModel)]="cell.str_ramp">
+                <mat-radio-group [(ngModel)]="cell.str_ramp"
+                                [disabled]="!speedLimitDisabled">
                     <mat-radio-button [value]="true">Yes</mat-radio-button>
                     <mat-radio-button [value]="false"[checked]='true'>No</mat-radio-button>
                 </mat-radio-group>
@@ -97,7 +101,8 @@
 
             <section class="radio-holder">
                 <label>Elevator</label>
-                <mat-radio-group [(ngModel)]="cell.str_elevator">
+                <mat-radio-group [(ngModel)]="cell.str_elevator"
+                                [disabled]="!speedLimitDisabled">
                     <mat-radio-button [value]="true">Yes</mat-radio-button>
                     <mat-radio-button [value]="false" [checked]='true'>No</mat-radio-button>
                 </mat-radio-group>

--- a/src/app/menus/edit-menu/edit-menu.component.ts
+++ b/src/app/menus/edit-menu/edit-menu.component.ts
@@ -54,8 +54,8 @@ export class EditMenuComponent implements OnInit {
         }
     }
 
-    onChangeLanes(event: any) {
-        if (event.value === 0) {
+    onChangeLanes(laneCount) {
+        if (laneCount === 0) {
             this.speedLimitDisabled = true;
             this.cell.str_speed = 7;
         } else {

--- a/src/app/menus/edit-menu/edit-menu.component.ts
+++ b/src/app/menus/edit-menu/edit-menu.component.ts
@@ -31,6 +31,9 @@ export class EditMenuComponent implements OnInit {
             }
             if (this.cell.str_numLanes > 0) {
                 this.speedLimitDisabled = false;
+                this.cell.str_ramp = false;
+                this.cell.str_stairs = false;
+                this.cell.str_elevator = false;
             }
         }
     }
@@ -52,11 +55,14 @@ export class EditMenuComponent implements OnInit {
     }
 
     onChangeLanes(event: any) {
-        console.log(event.value)
         if (event.value === 0) {
             this.speedLimitDisabled = true;
+            this.cell.str_speed = 7;
         } else {
             this.speedLimitDisabled = false;
+            this.cell.str_ramp = false;
+            this.cell.str_stairs = false;
+            this.cell.str_elevator = false;
         }
 
     }

--- a/src/app/menus/edit-menu/edit-menu.component.ts
+++ b/src/app/menus/edit-menu/edit-menu.component.ts
@@ -54,7 +54,7 @@ export class EditMenuComponent implements OnInit {
         }
     }
 
-    onChangeLanes(laneCount) {
+    onChangeLanes(laneCount: number) {
         if (laneCount === 0) {
             this.speedLimitDisabled = true;
             this.cell.str_speed = 7;

--- a/src/app/menus/edit-menu/edit-menu.component.ts
+++ b/src/app/menus/edit-menu/edit-menu.component.ts
@@ -18,6 +18,7 @@ export class EditMenuComponent implements OnInit {
     cell: GridCell = new GridCell();
     isDismissed = false;
     sliderDisabled = true;
+    speedLimitDisabled = true;
 
     constructor() {
     }
@@ -25,8 +26,11 @@ export class EditMenuComponent implements OnInit {
     ngOnInit() {
         if (this.currentCell) {
             this.cell = Object.assign({}, this.currentCell);
-            if(this.cell.bld_numLevels > 1) {
+            if (this.cell.bld_numLevels > 1) {
                 this.sliderDisabled = false;
+            }
+            if (this.cell.str_numLanes > 0) {
+                this.speedLimitDisabled = false;
             }
         }
     }
@@ -39,13 +43,22 @@ export class EditMenuComponent implements OnInit {
     }
 
     onChangeSlider(event: any) {
-        if(event.value === 1) {
+        if (event.value === 1) {
             this.sliderDisabled = true;
-            this.cell.bld_useUpper = null
-        }
-        else {
+            this.cell.bld_useUpper = null;
+        } else {
             this.sliderDisabled = false;
         }
+    }
+
+    onChangeLanes(event: any) {
+        console.log(event.value)
+        if (event.value === 0) {
+            this.speedLimitDisabled = true;
+        } else {
+            this.speedLimitDisabled = false;
+        }
+
     }
 
     // Button actions


### PR DESCRIPTION
building and open space use rehaul:
- promenade ~= street
- accordingly (de)activate UI elements automatically
- new type: grocery store
- added walkability layer for grocery stores
- changed display names of educational, culture
- removed unneeded types from front end